### PR TITLE
transcribe: Add missing text variable to fix UnboundLocalError.

### DIFF
--- a/plugins/transcribe.py
+++ b/plugins/transcribe.py
@@ -39,6 +39,7 @@ class WitAiAPI:
         823b1423832b7117ad41c83abb3e25d58dd9e789/src/audiotools/
         speech.py#L13
         """
+        text = ""
         error = ""
         headers = {
             'authorization': f'Bearer {self.api_keys[lang]}',


### PR DESCRIPTION
fixes:
```
Traceback (most recent call last):
  File "/app/userge/core/methods/decorators/raw_decorator.py", line 314, in template
    await func(types.bound.Message.parse(
  File "/app/userge/plugins/unofficial/transcribe.py", line 171, in stt_
    async for _, error in api.transcribe(file_path):
  File "/app/userge/plugins/unofficial/transcribe.py", line 95, in transcribe
    text, error = await self.__transcribe_chunk(chunk, self.lang)
  File "/app/userge/plugins/unofficial/transcribe.py", line 59, in __transcribe_chunk
    return text, error
UnboundLocalError: local variable 'text' referenced before assignment
```