### PR TITLE
Removed hide_via parameter

### DIFF
--- a/plugins/fun/animesticker/__main__.py
+++ b/plugins/fun/animesticker/__main__.py
@@ -48,8 +48,7 @@ async def anime_sticker(message: Message):
             await userge.send_inline_bot_result(
                 chat_id=message.chat.id,
                 query_id=stickers.query_id,
-                result_id=stickers.results[0].id,
-                hide_via=True)
+                result_id=stickers.results[0].id)
         except IndexError:
             await message.err("List index out of range")
         else:
@@ -71,8 +70,7 @@ async def anime_sticker(message: Message):
         saved = await userge.send_inline_bot_result(
             chat_id="me",
             query_id=stickers.query_id,
-            result_id=stickers.results[0].id,
-            hide_via=True
+            result_id=stickers.results[0].id
         )
         saved = await userge.get_messages("me", int(saved.updates[1].message.id))
         message_id = replied.message_id if replied else None

--- a/plugins/utils/pmpermit/__main__.py
+++ b/plugins/utils/pmpermit/__main__.py
@@ -306,7 +306,7 @@ async def uninvitedPmHandler(message: Message):
                 k = await userge.get_inline_bot_results(bot_username, "pmpermit")
                 await userge.send_inline_bot_result(
                     message.chat.id, query_id=k.query_id,
-                    result_id=k.results[0].id, hide_via=True
+                    result_id=k.results[0].id
                 )
             except (IndexError, BotInlineDisabled):
                 await message.reply(


### PR DESCRIPTION
Removed `hide_via` parameter from [send_inline_bot_result](https://github.com/pyrogram/pyrogram/commit/0c0a4b5a5c8f20a0df9dcea843271d3ab0009c68) functions.