### PR TITLE
Add Support For Catbox.moe File Uploads

### DIFF
--- a/plugins/misc/webupload/__main__.py
+++ b/plugins/misc/webupload/__main__.py
@@ -18,7 +18,7 @@ from userge.utils import progress
 
 
 @userge.on_cmd("web ?(.+?|) (anonfiles|transfer|filebin|anonymousfiles"
-               "|megaupload|bayfiles|vshare|0x0|fileio|ninja|infura|bashupload)",
+               "|megaupload|bayfiles|vshare|0x0|fileio|ninja|infura|bashupload|cat)",
                about={
                    'header': "upload files to web",
                    'usage': "{tr}web [file path | reply to media] [site name]",
@@ -26,7 +26,7 @@ from userge.utils import progress
                    'types': [
                        'anonfiles', 'transfer', 'filebin', 'anonymousfiles',
                        'megaupload', 'bayfiles', 'vshare', '0x0', 'fileio',
-                       'ninja', 'infura', 'bashupload']})
+                       'ninja', 'infura', 'bashupload', 'cat']})
 async def web(message: Message):
     await message.edit("`Processing ...`")
     input_str = message.matches[0].group(1)

--- a/plugins/misc/webupload/__main__.py
+++ b/plugins/misc/webupload/__main__.py
@@ -57,6 +57,7 @@ async def web(message: Message):
         "bashupload": "curl -T \"{}\" https://bashupload.com",
         "fileio": "curl -F \"file =@{}\" https://file.io",
         "ninja": "curl -i -F file=@{} https://tmp.ninja/api.php?d=upload-tool",
+        "cat": "curl -F reqtype=fileupload -F \"fileToUpload=@{}\" https://catbox.moe/user/api.php",
         "infura": "curl -X POST -F file=@'{}' \"https://ipfs.infura.io:5001/api/v0/add?pin=true\""
     }
 


### PR DESCRIPTION
Added support for uploading files to catbox.moe. This host is faster than existing options & allows for uploads upto 1GB in size.