### PR TITLE
Domain Doesn't Show Available Flag Options

### DIFF
--- a/plugins/utils/domain/__main__.py
+++ b/plugins/utils/domain/__main__.py
@@ -26,7 +26,7 @@ from userge import userge, Message
     allow_via_bot=False
 )
 async def creator(m: Message) -> None:
-    """ View Your Domain """
+    """ View Your Domain\nFlags:\n-c: List all groups & channels created by you.\n-a: List all groups and channels administered by you"""
 
     await m.edit("__This may take a while, please wait ...__")
 

--- a/plugins/utils/domain/__main__.py
+++ b/plugins/utils/domain/__main__.py
@@ -25,7 +25,8 @@ from userge import userge, Message
     },
     allow_via_bot=False
 )
-async def creator(m: Message):
+async def creator(m: Message) -> None:
+    """ View Your Domain """
 
     await m.edit("__This may take a while, please wait ...__")
 
@@ -85,7 +86,8 @@ async def creator(m: Message):
 @userge.on_cmd("stats",
                about="Shows user account stats!",
                allow_via_bot=False)
-async def stats(message: Message):
+async def stats(message: Message) -> None:
+    """ Your accounts stats """
     await message.edit("Processing ...This may take a bit time")
     u = 0
     g = 0

--- a/plugins/utils/domain/__main__.py
+++ b/plugins/utils/domain/__main__.py
@@ -26,7 +26,7 @@ from userge import userge, Message
     allow_via_bot=False
 )
 async def creator(m: Message) -> None:
-    """ View Your Domain\nFlags:\n-c: List all groups & channels created by you.\n-a: List all groups and channels administered by you"""
+    """ View Your Domain\n*Flags:*\n-c: List all groups & channels created by you.\n-a: List all groups and channels administered by you\n"""
 
     await m.edit("__This may take a while, please wait ...__")
 

--- a/plugins/utils/domain/__main__.py
+++ b/plugins/utils/domain/__main__.py
@@ -26,7 +26,9 @@ from userge import userge, Message
     allow_via_bot=False
 )
 async def creator(m: Message) -> None:
-    """ View Your Domain\nAvailable Flags:\n-c: List all groups & channels created by you.\n-a: List all groups and channels administered by you"""
+    "View Your Domain\nAvailable Flags:\n"\
+    "-c: List all groups & channels created by you."\
+    "-a: List all groups and channels administered by you"
 
     await m.edit("__This may take a while, please wait ...__")
 

--- a/plugins/utils/domain/__main__.py
+++ b/plugins/utils/domain/__main__.py
@@ -26,7 +26,7 @@ from userge import userge, Message
     allow_via_bot=False
 )
 async def creator(m: Message) -> None:
-    """ View Your Domain\nAvailable Flags:\n-c: List all groups & channels created by you.\n-a: List all groups and channels administered by you\n\n"""
+    """ View Your Domain\nAvailable Flags:\n-c: List all groups & channels created by you.\n-a: List all groups and channels administered by you"""
 
     await m.edit("__This may take a while, please wait ...__")
 

--- a/plugins/utils/domain/__main__.py
+++ b/plugins/utils/domain/__main__.py
@@ -27,7 +27,7 @@ from userge import userge, Message
 )
 async def creator(m: Message) -> None:
     "View Your Domain\nAvailable Flags:\n"\
-    "-c: List all groups & channels created by you."\
+    "-c: List all groups & channels created by you.\n"\
     "-a: List all groups and channels administered by you"
 
     await m.edit("__This may take a while, please wait ...__")

--- a/plugins/utils/domain/__main__.py
+++ b/plugins/utils/domain/__main__.py
@@ -113,5 +113,5 @@ async def stats(message: Message):
 `You are in __{}__ Super Groups.`
 `You Are in __{}__ Channels.`
 `You Are Admin in __{}__ Chats.`
-`Bots Started = __{}__`
+`Bots Started = __{}__Times`
 '''.format(u, g, sg, c, a_chat, b))

--- a/plugins/utils/domain/__main__.py
+++ b/plugins/utils/domain/__main__.py
@@ -26,7 +26,7 @@ from userge import userge, Message
     allow_via_bot=False
 )
 async def creator(m: Message) -> None:
-    """ View Your Domain\n*Flags:*\n-c: List all groups & channels created by you.\n-a: List all groups and channels administered by you\n"""
+    """ View Your Domain\nAvailable Flags:\n-c: List all groups & channels created by you.\n-a: List all groups and channels administered by you\n\n"""
 
     await m.edit("__This may take a while, please wait ...__")
 


### PR DESCRIPTION
Attempt to display the available flag options for the command .domain

Doing .help domain does not show the available flag options and doing .domain executes the command & throws an error as the user did not specify any flags.

This is an attemp to correct this by letting the user know a flag is required, as well as the options available.

(This probably can be done better but works for now) 